### PR TITLE
added syntax hl for css inside mj-style tag

### DIFF
--- a/syntax/mjml.vim
+++ b/syntax/mjml.vim
@@ -12,7 +12,6 @@ syntax keyword htmlTagName contained mj-chart mj-qr-code mjml-msobutton
 
 syntax match   htmlArg     contained /\k\+=\@=/
 
-syntax include @htmlCss syntax/css.vim
 syntax region cssMjStyle start=+<mj-style>+ keepend end=+</mj-style>+ contains=@htmlCss,htmlTag,htmlEndTag,htmlCssStyleComment,@htmlPreproc
 
 let b:current_syntax = 'mjml'

--- a/syntax/mjml.vim
+++ b/syntax/mjml.vim
@@ -12,5 +12,8 @@ syntax keyword htmlTagName contained mj-chart mj-qr-code mjml-msobutton
 
 syntax match   htmlArg     contained /\k\+=\@=/
 
+syntax include @htmlCss syntax/css.vim
+syntax region cssMjStyle start=+<mj-style>+ keepend end=+</mj-style>+ contains=@htmlCss,htmlTag,htmlEndTag,htmlCssStyleComment,@htmlPreproc
+
 let b:current_syntax = 'mjml'
 unlet main_syntax


### PR DESCRIPTION
Highlighting surrounded by `<mj-style>` should work with this. 
Note that this only has been tested interactively so no guarantees that all cases are covered.

Borrowed and modified the relevant lines from `syntax/html.vim`.