### PR TITLE
Allow for mj-style element's optional attribute

### DIFF
--- a/syntax/mjml.vim
+++ b/syntax/mjml.vim
@@ -12,7 +12,7 @@ syntax keyword htmlTagName contained mj-chart mj-qr-code mjml-msobutton
 
 syntax match   htmlArg     contained /\k\+=\@=/
 
-syntax region cssMjStyle start=+<mj-style>+ keepend end=+</mj-style>+ contains=@htmlCss,htmlTag,htmlEndTag,htmlCssStyleComment,@htmlPreproc
+syntax region cssMjStyle start=+<mj-style[^>]*>+ keepend end=+</mj-style>+ contains=@htmlCss,htmlTag,htmlEndTag,htmlCssStyleComment,@htmlPreproc
 
 let b:current_syntax = 'mjml'
 unlet main_syntax


### PR DESCRIPTION
For example `<mj-style inline="inline">`.